### PR TITLE
Add waking task batcher class with default and random task batching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ jobs
 data/geom/**/*.png
 rust_compressor/target
 *.cost
+compressionMessages/
+container.img
+launchers/
+message

--- a/taskBatcher.py
+++ b/taskBatcher.py
@@ -1,0 +1,41 @@
+from utilities import eprint
+import random
+
+class DefaultTaskBatcher:
+	"""Iterates through task batches of the specified size. Defaults to all tasks if taskBatchSize is None."""
+
+	def __init__(self):
+		pass
+
+	def getTaskBatch(self, ec_result, tasks, taskBatchSize, currIteration):
+		if taskBatchSize is None:
+			taskBatchSize = len(tasks)
+		elif taskBatchSize > len(tasks):
+			eprint("Task batch size is greater than total number of tasks, aborting.")
+			assert False
+		
+
+		start = (taskBatchSize * currIteration) % len(tasks)
+		end = start + taskBatchSize
+		taskBatch = (tasks + tasks)[start:end] # Handle wraparound.
+		return taskBatch
+
+class RandomTaskTaskBatcher:
+	"""Returns a randomly sampled task batch of the specified size. Defaults to all tasks if taskBatchSize is None."""
+
+	def __init__(self):
+		pass
+
+	def getTaskBatch(self, ec_result, tasks, taskBatchSize, currIteration):
+		if taskBatchSize is None:
+			taskBatchSize = len(tasks)
+		elif taskBatchSize > len(tasks):
+			eprint("Task batch size is greater than total number of tasks, aborting.")
+			assert False
+
+		return random.sample(tasks, taskBatchSize)
+
+
+
+
+

--- a/taskBatcher.py
+++ b/taskBatcher.py
@@ -34,8 +34,4 @@ class RandomTaskTaskBatcher:
 			assert False
 
 		return random.sample(tasks, taskBatchSize)
-
-
-
-
-
+		


### PR DESCRIPTION
Adds two really simple task batchers (DefaultTaskBatcher and RandomTaskBatcher):
1. Adds taskBatchSize and taskReranker as command line arguments, and
2. Creates taskBatcher.py with the general proposed getTaskBatch method signature.

TaskBatchers work by creating some subset of tasks during each wake iteration and then passing that subset in to the waking enumerator methods.

Mostly making this as a first small change to the codebase to get any and all feedback re: style, approach, etc before getting deeper in.

One last thing to note: taskBatchers will probably want to take in ECResult objects, which are currently in ec.py (which uses taskBatchers). Should we factor this out somehow to avoid circular imports?