### PR TITLE
Add fix for regression with unpickling old checkpoint files

### DIFF
--- a/bin/graphs.py
+++ b/bin/graphs.py
@@ -14,6 +14,9 @@ import matplotlib.lines as mlines
 import matplotlib
 #from test_unpickle import loadfun
 
+# Required import for unpickling older checkpoints:
+from dreamcoder.domains.tower.main import TowerCNN
+
 
 def loadfun(x):
     with open(x, 'rb') as handle:


### PR DESCRIPTION
Tested with the following pickle file sent from Kevin:
```
python bin/graphs.py --checkpoints /Users/lcary/w/mit/dreamcoder-testing/out/tower_aic=1.0_arity=3_BO=True_CO=True_ES=1_ET=3600_HR=0.5_it=20_MF=5_pc=30.0_RS=5000_RT=3600_RR=False_RW=False_STM=True_L=1.5_batch=50_TRR=randomShuffle_K=2_topkNotMAP=False.pickle --export test.png
```

Output file:

![test](https://user-images.githubusercontent.com/6766704/61652813-d3c4dc80-ac86-11e9-8aa5-2a5daa766d67.png)
