### PR TITLE
Update creating-new-domains.md

### DIFF
--- a/docs/creating-new-domains.md
+++ b/docs/creating-new-domains.md
@@ -72,8 +72,8 @@ We will create a list of primitives for our toy example next.
 
 Each member of our list must be an instance of the `Primitive` class where each primitive has a unique name that binds it to its corresponding OCaml code (discussed later), a type imported from `dreamcoder/type.py`, and a lambda function: `Primitive(name, type, func)`.
 ```python
-def _incr(x): return lambda x: x + 1
-def _incr2(x): return lambda x: x + 2
+def _incr(x): return x + 1
+def _incr2(x): return x + 2
 
 primitives = [
     Primitive("incr", arrow(tint, tint), _incr),
@@ -190,8 +190,8 @@ from dreamcoder.type import arrow, tint
 from dreamcoder.utilities import numberOfCPUs
 
 # Primitives
-def _incr(x): return lambda x: x + 1
-def _incr2(x): return lambda x: x + 2
+def _incr(x): return x + 1
+def _incr2(x): return x + 2
 
 
 def addN(n):


### PR DESCRIPTION
Fixed incr primitives for the example domain to work with python and pypy solver.  If a lambda function is returned, the example domain will never find a solution to the tasks because Python always compares a lambda function to an integer when evaluating programs. 